### PR TITLE
Replace obsolete stx-btree with tlx.

### DIFF
--- a/examples/svbs.h
+++ b/examples/svbs.h
@@ -20,7 +20,7 @@
  */
 
 #include <treedec/degree_config.hpp>
-#include <stx/btree_set.h>
+#include <tlx/container/btree_set.hpp>
 
 template<class G>
 struct m_deg_config : public misc::detail::deg_config<G> {
@@ -45,4 +45,4 @@ template<class G>
 struct svbs_config : public gala::graph_cfg_default<G> {
 };
 
-typedef gala::graph< stx::btree_set, std::vector, gala::vertex_ptr_tag, svbs_config> simplegraph_vector_bs;
+typedef gala::graph< tlx::btree_set, std::vector, gala::vertex_ptr_tag, svbs_config> simplegraph_vector_bs;

--- a/examples/svbs_random.h
+++ b/examples/svbs_random.h
@@ -58,7 +58,7 @@ struct svbs_config : public gala::graph_cfg_default<G> {
 };
 }
 
-typedef gala::graph< stx::btree_set, std::vector, gala::vertex_ptr_tag, svbsr::svbs_config> svbs_random;
+typedef gala::graph< tlx::btree_set, std::vector, gala::vertex_ptr_tag, svbsr::svbs_config> svbs_random;
 
 namespace treedec{
 template<>

--- a/graph.h
+++ b/graph.h
@@ -27,8 +27,8 @@
 #include <vector>
 #include <map>
 #include <forward_list>
-#ifdef HAVE_STX_BTREE_SET_H
-#include <stx/btree_set.h>
+#ifdef HAVE_TLX_CONTAINER_BTREE_SET_HPP
+#include <tlx/container/btree_set.hpp>
 #endif
 #include <type_traits>
 		
@@ -2169,7 +2169,7 @@ graph<SGARGS>& graph<SGARGS>::assign_same(graph<SGARGS> const& x)
 			EL const& S = x.out_edges(sd); // ?!
 			bits::vertex_helper<VDP>::rebase(E, S, delta);
 #if 0
-			incomplete();// does not work for stx
+			incomplete();// does not work for tlx
 
 			EL& MS = const_cast<EL&>(S); // HACK!?
 			E = MS;

--- a/sethack.h
+++ b/sethack.h
@@ -23,8 +23,8 @@
 
 #define likely(x)       __builtin_expect((x),1)
 #define unlikely(x)     __builtin_expect((x),0)
-#ifdef HAVE_STX_BTREE_SET_H
-#include <stx/btree_set.h>
+#ifdef HAVE_TLX_CONTAINER_BTREE_SET_HPP
+#include <tlx/container/btree_set.hpp>
 #endif
 #include <set>
 #include <unordered_set>
@@ -136,10 +136,10 @@ struct sethack_{ //
 	}
 };
 /*--------------------------------------------------------------------------*/
-#ifdef HAVE_STX_BTREE_SET_H
+#ifdef HAVE_TLX_CONTAINER_BTREE_SET_HPP
 template<>
-struct sethack_<stx::btree_set<size_t> >{ //
-	typedef stx::btree_set<size_t> S;
+struct sethack_<tlx::btree_set<size_t> >{ //
+	typedef tlx::btree_set<size_t> S;
 	static typename S::iterator reverse(typename S::reverse_iterator& x)
 	{untested();
 		return S::iterator(x);

--- a/sfinae.h
+++ b/sfinae.h
@@ -28,8 +28,8 @@
 
 #include <deque>
 #include <set>
-#ifdef HAVE_STX_BTREE_SET_H
-#include <stx/btree_set.h>
+#ifdef HAVE_TLX_CONTAINER_BTREE_SET_HPP
+#include <tlx/container/btree_set.hpp>
 #endif
 // #endif
 #include <boost/container/flat_set.hpp>
@@ -75,10 +75,10 @@ std::set<typename S::value_type, typename S::key_compare, typename S::allocator_
 	static constexpr bool value = true;
 
 };
-#ifdef HAVE_STX_BTREE_SET_H
+#ifdef HAVE_TLX_CONTAINER_BTREE_SET_HPP
 template<class S, class T>
 struct is_set<S, typename std::enable_if < std::is_same<
-stx::btree_set<typename S::value_type, typename S::key_compare, typename S::allocator_type >, S
+tlx::btree_set<typename S::value_type, typename S::key_compare, typename S::allocator_type >, S
 >::value, any >::type , T>{ //
 
 	typedef T type;


### PR DESCRIPTION
The stx-btree page says that the project is obsolete, and tlx should be used instead.